### PR TITLE
Improved injector, resolve domain names to the preferred IP version

### DIFF
--- a/src/injector/argsParser.h
+++ b/src/injector/argsParser.h
@@ -4,7 +4,7 @@
 struct ProgramArgs {
     std::wstring gothic{L"System\\Gothic2.exe"};
     std::wstring dll{L"gmp\\gmp.dll"};
-    std::wstring host{L"localhost|28960"};
+    std::wstring host{L"localhost:28960"};
     std::wstring nickname;
     std::wstring debugLevel{L"-1"};
     bool enableGothicException{false};
@@ -38,7 +38,7 @@ inline ProgramArgs parseProgramArgs(int argc, wchar_t *argv[]) {
             puts("Usage: gmpinjector [options]\nOptions:");
             printf("  %ls\tPath to the Gothic executable. Defaults to %ls\n", gothicArg, programArgs.gothic.c_str());
             printf("  %ls\tPath to the GMP client DLL. Defaults to %ls\n", dllArg, programArgs.dll.c_str());
-            printf("  %ls\tHost and port of the server to connect to, seperated by '|'. Defaults to %ls\n", hostArg, programArgs.host.c_str());
+            printf("  %ls\tHost and port of the server to connect to, seperated by ':'. Defaults to %ls\n", hostArg, programArgs.host.c_str());
             printf("  %ls\tNickname to use on the server. By default, the server will generate a nickname for you\n", nicknameArg);
             printf("  %ls<0-9>\tDebug level of the zSpy. By default, logging is deactivated (-1). If activated, will start the zSpy in the Gothic directory\n", debugLevelArg);
             printf("  %ls\tWhether to use the Gothic exception handler. Defaults to %s\n", exceptionArg, (programArgs.enableGothicException ? "true" : "false"));

--- a/src/injector/argsParser.h
+++ b/src/injector/argsParser.h
@@ -35,9 +35,13 @@ inline ProgramArgs parseProgramArgs(int argc, wchar_t *argv[]) {
         } else if (arg.find(exceptionArg) != std::wstring_view::npos) {
             programArgs.enableGothicException = true;
         } else if (arg.find(helpArg) != std::wstring_view::npos) {
-            printf(
-                "usage: gmpinjector [%ls] [%ls<path>] [%ls<path>] [%ls<host:port>] [%ls<name>] [%ls<number>] [%ls]\n",
-                helpArg, gothicArg, dllArg, hostArg, nicknameArg, debugLevelArg, exceptionArg);
+            puts("Usage: gmpinjector [options]\nOptions:");
+            printf("  %ls\tPath to the Gothic executable. Defaults to %ls\n", gothicArg, programArgs.gothic.c_str());
+            printf("  %ls\tPath to the GMP client DLL. Defaults to %ls\n", dllArg, programArgs.dll.c_str());
+            printf("  %ls\tHost and port of the server to connect to, seperated by '|'. Defaults to %ls\n", hostArg, programArgs.host.c_str());
+            printf("  %ls\tNickname to use on the server. By default, the server will generate a nickname for you\n", nicknameArg);
+            printf("  %ls<0-9>\tDebug level of the zSpy. By default, logging is deactivated (-1). If activated, will start the zSpy in the Gothic directory\n", debugLevelArg);
+            printf("  %ls\tWhether to use the Gothic exception handler. Defaults to %s\n", exceptionArg, (programArgs.enableGothicException ? "true" : "false"));
             std::exit(EXIT_SUCCESS);
         }
     }

--- a/src/injector/argsParser.h
+++ b/src/injector/argsParser.h
@@ -2,9 +2,9 @@
 #include <string>
 
 struct ProgramArgs {
-    std::wstring gothic{L"Gothic2.exe"};
+    std::wstring gothic{L"System\\Gothic2.exe"};
     std::wstring dll{L"gmp\\gmp.dll"};
-    std::wstring host{L"localhost:28960"};
+    std::wstring host{L"localhost|28960"};
     std::wstring nickname;
     std::wstring debugLevel{L"-1"};
     bool enableGothicException{false};

--- a/src/injector/main.cpp
+++ b/src/injector/main.cpp
@@ -1,5 +1,5 @@
-#include "Windows.h"
-#include "tlhelp32.h"
+#include <windows.h>
+#include <tlhelp32.h>
 #include "win32Utils.h"
 #include "argsParser.h"
 #include "zSpy.h"
@@ -7,13 +7,13 @@
 
 int inject(const ProgramArgs &programArgs) {
     if (!fileExists(programArgs.gothic)) {
-        fprintf(stderr, "Gothic EXE not found in path \"%ls\"\n", programArgs.gothic.c_str());
+        fprintf(stderr, "Gothic EXE not found in path \"%ls\". Please specify the path with --gothic=\n", programArgs.gothic.c_str());
         return EXIT_FAILURE;
     }
 
     const std::wstring dllAbsolutePath = absolutePath(programArgs.dll);
     if (!fileExists(dllAbsolutePath)) {
-        fprintf(stderr, "GMP DLL not found in path \"%ls\"\n", dllAbsolutePath.c_str());
+        fprintf(stderr, "GMP DLL not found in path \"%ls\". Please specify the path with --dll=\n", programArgs.dll.c_str());
         return EXIT_FAILURE;
     }
 

--- a/src/injector/win32Utils.h
+++ b/src/injector/win32Utils.h
@@ -1,13 +1,14 @@
 #pragma once
-#include "Windows.h"
+#include <windows.h>
 #include <memory>
 #include <string>
+#include <string_view>
 
 inline bool isSlash(const wchar_t c) {
     return c == L'\\' || c == L'/';
 }
 
-inline std::wstring parentPath(const std::wstring &path) {
+inline std::wstring parentPath(const std::wstring_view path) {
     const wchar_t *const first = path.data();
     const wchar_t *last = first + path.size();
     // Remove everything until the first slash
@@ -22,23 +23,31 @@ inline std::wstring parentPath(const std::wstring &path) {
     return {first, last};
 }
 
-inline std::wstring absolutePath(const std::wstring &path) {
-    const DWORD size = GetFullPathNameW(path.c_str(), 0, nullptr, nullptr);
-    std::wstring absolutePath;
-    absolutePath.resize(size);
-    GetFullPathNameW(path.c_str(), size, absolutePath.data(), nullptr);
+inline std::wstring absolutePath(const std::wstring_view path) {
+    const DWORD size = GetFullPathNameW(path.data(), 0, nullptr, nullptr);
+    std::wstring absolutePath(size, '\0');
+    GetFullPathNameW(path.data(), size, absolutePath.data(), nullptr);
     return absolutePath;
 }
 
-inline bool fileExists(const std::wstring &path) {
-    DWORD result = GetFileAttributesW(path.c_str());
+inline bool fileExists(const std::wstring_view path) {
+    DWORD result = GetFileAttributesW(path.data());
     return result != INVALID_FILE_ATTRIBUTES && (result & FILE_ATTRIBUTE_DIRECTORY) == 0U;
 }
 
-inline bool isProcessRunning(const std::wstring &process) {
-    using unique_handle = std::unique_ptr<std::remove_pointer_t<HANDLE>, decltype(&CloseHandle)>;
+inline bool isProcessRunning(const std::wstring_view process) {
+    struct handle_deleter
+    {
+        using pointer = HANDLE;
 
-    const unique_handle snapshot(CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0), CloseHandle);
+        void operator()(pointer handle)
+        {
+            CloseHandle(handle);
+        }
+    };
+    using unique_handle = std::unique_ptr<HANDLE, handle_deleter>;
+
+    const unique_handle snapshot(CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0));
     if (snapshot.get() == INVALID_HANDLE_VALUE) {
         fprintf(stderr, "Couldn't create Toolhelp32Snapshot. GetLastError: %lu", GetLastError());
         return false;

--- a/src/injector/win32Utils.h
+++ b/src/injector/win32Utils.h
@@ -23,15 +23,15 @@ inline std::wstring parentPath(const std::wstring_view path) {
     return {first, last};
 }
 
-inline std::wstring absolutePath(const std::wstring_view path) {
-    const DWORD size = GetFullPathNameW(path.data(), 0, nullptr, nullptr);
+inline std::wstring absolutePath(const std::wstring& path) {
+    const DWORD size = GetFullPathNameW(path.c_str(), 0, nullptr, nullptr);
     std::wstring absolutePath(size, '\0');
-    GetFullPathNameW(path.data(), size, absolutePath.data(), nullptr);
+    GetFullPathNameW(path.c_str(), size, absolutePath.data(), nullptr);
     return absolutePath;
 }
 
-inline bool fileExists(const std::wstring_view path) {
-    DWORD result = GetFileAttributesW(path.data());
+inline bool fileExists(const std::wstring& path) {
+    DWORD result = GetFileAttributesW(path.c_str());
     return result != INVALID_FILE_ATTRIBUTES && (result & FILE_ATTRIBUTE_DIRECTORY) == 0U;
 }
 

--- a/src/launcher/CMakeLists.txt
+++ b/src/launcher/CMakeLists.txt
@@ -9,7 +9,7 @@ set(SLIKENET_ENABLE_DLL OFF CACHE INTERNAL "")
 include(FetchContent)
 FetchContent_Declare(slikenet
         GIT_REPOSITORY https://gitlab.com/Sabrosa/slikenet.git
-        GIT_TAG        0621404add46ac03decb1b46fed8fd79e982abbc
+        GIT_TAG        922482ad604839db15fbd9a5f08fe5fe6b545405
 )
 FetchContent_MakeAvailable(slikenet)
 

--- a/src/launcher/gmpclient.cpp
+++ b/src/launcher/gmpclient.cpp
@@ -48,17 +48,19 @@ void GMPClient::start(const QString &address, quint16 port)
     (void)QtConcurrent::run(QThreadPool::globalInstance(), [this, address, port]{
         constexpr char password[] = "b5r6kQ6gp0GcpK4x";
 
-        SLNet::ConnectionAttemptResult result;
-        for (unsigned int socket = 0; socket < 2; socket++) {
-            result = m_pClient->Connect(address.toStdString().c_str(), port, password, sizeof(password) - 1, nullptr, socket);
-            if (result == SLNet::CONNECTION_ATTEMPT_STARTED) {
-                emit startTimer();
-                return;
-            }
+        // resolve domain to IP
+        SLNet::SystemAddress ip(address.toStdString().c_str(), port);
+        int socket = 0;
+        if (ip.GetIPVersion() == 6)
+            socket = 1;
+        SLNet::ConnectionAttemptResult result = m_pClient->Connect(ip.ToString(false), ip.GetPort(), password, sizeof(password) - 1, nullptr, socket);
+        if (result == SLNet::CONNECTION_ATTEMPT_STARTED) {
+            emit startTimer();
+            return;
         }
 
         ServerInfo info;
-        switch(result){
+        switch(result) {
             case SLNet::INVALID_PARAMETER:
                 info.serverName = "Invalid Parameter";
                 break;

--- a/src/launcher/mainwindow.cpp
+++ b/src/launcher/mainwindow.cpp
@@ -122,9 +122,10 @@ void MainWindow::startProcess()
     const QFileInfo gmpDllPath(s.value("gmp_dll", "gmp/gmp.dll").toString());
 
     const int row = index.front().row();
-    const QString host = m_pServerModel->data(m_pServerModel->index(row, Server::P_Url), Qt::DisplayRole).toString()
-            + '|'
-            + QString::number(m_pServerModel->data(m_pServerModel->index(row, Server::P_Port), Qt::DisplayRole).toUInt());
+    QString host = m_pServerModel->data(m_pServerModel->index(row, Server::P_Url), Qt::DisplayRole).toString();
+    if (host.contains(':')) // IPv6 address
+        host.prepend('[').append(']');
+    host += ':' + QString::number(m_pServerModel->data(m_pServerModel->index(row, Server::P_Port), Qt::DisplayRole).toUInt());
     const QString nick = m_pServerModel->data(m_pServerModel->index(row, Server::P_Nick), Qt::DisplayRole).toString();
 
 #ifdef _WIN32

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -1,7 +1,7 @@
 {
   "default-registry": {
     "kind": "git",
-    "baseline": "1ab9f77003f836c45797db3fa1daf3cfc15262cb",
+    "baseline": "b94ab47c998b93fe72b0f501eaac70f96328019e",
     "repository": "https://github.com/microsoft/vcpkg"
   },
   "registries": [


### PR DESCRIPTION
So far, the launcher only tried IPv6 if the address couldn't be resolved to an IPv4 address, so almost only when an IPv6 address was entered. Now, it will use the first address returned by `getaddrinfo()`, which normally will be IPv6 if IPv6 is available (the client has at least one IPv6 address that is not the loopback address).